### PR TITLE
when mongo server is not available, routine will log this message instead of die the process

### DIFF
--- a/Mongoq.php
+++ b/Mongoq.php
@@ -1205,7 +1205,7 @@ class Mongoq{
 			} 
 			catch( MongoConnectionException $e ) 
 			{ 
-				log_message('error', 'MongoDB ERROR: ' . $e->getMessage());
+                log_message('error', 'MongoDB ERROR: ' . $e->getMessage());
 			}
 		}
 		else
@@ -1240,8 +1240,7 @@ class Mongoq{
 		$this->hostname = $this->CI->config->item("hostname");
 		$this->port = $this->CI->config->item("port");
 		$this->replica = $this->CI->config->item("replica_set");
-        $this->connectTimeoutMS = $this->CI->config->item('connectTimeoutMS');
-        var_dump($this->connectTimeoutMS);
+		$this->connectTimeoutMS = $this->CI->config->item('connectTimeoutMS');
 
 		$use_persist = $this->CI->config->item("persist");
 		if( phpversion('mongo') < 1.3 && $use_persist ) 

--- a/mongo.php
+++ b/mongo.php
@@ -8,5 +8,6 @@ $config["dbname"] = "Enter your Database name for use";
 $config["persist"] = true; // default : true
 $config["persist_key"] = "ci_mongodb_persist";
 $config["replica_set"] = false; // default : false;
+$config["connectTimeoutMS"] = 3000;// default : 3 seconds
 
-?>
+/* End of file mongo.php */


### PR DESCRIPTION
I used the mongoq lib in my project , It's very awesome.

I found if I use this in some serious occasion , when routine can't install mongo connection the process will die , so I change the action to log the error message.

Also I build a method that can detect ethier the connection was installed successfully or not , it can use in some scenario to avoid calling mongo method when connection was failed to installed. 
